### PR TITLE
Add named args and kwargs instead of parameters dict

### DIFF
--- a/src/replit/ai/chat_model.py
+++ b/src/replit/ai/chat_model.py
@@ -18,7 +18,7 @@ class ChatModel(Model):
     super().__init__(**kwargs)
     self.model_name = model_name
 
-  def generate(self,
+  def chat(self,
                prompts: List[ChatSession],
                max_output_tokens: int = 1024,
                temperature: float = 0.0,
@@ -45,7 +45,7 @@ class ChatModel(Model):
     self._check_response(response)
     return ChatModelResponse(**response.json())
 
-  async def async_generate(self,
+  async def async_chat(self,
                            prompts: List[str],
                            max_output_tokens: int = 1024,
                            temperature: float = 0.0,
@@ -73,7 +73,7 @@ class ChatModel(Model):
         await self._check_aresponse(response)
         return ChatModelResponse(**await response.json())
 
-  def generate_stream(self,
+  def stream_chat(self,
                       prompts: List[str],
                       max_output_tokens: int = 1024,
                       temperature: float = 0.0,
@@ -101,7 +101,7 @@ class ChatModel(Model):
     for chunk in self._parse_streaming_response(response):
       yield ChatModelResponse(**chunk)
 
-  async def async_generate_stream(self,
+  async def async_stream_chat(self,
                                   prompts: List[str],
                                   max_output_tokens: int = 1024,
                                   temperature: float = 0.0,

--- a/src/replit/ai/completion_model.py
+++ b/src/replit/ai/completion_model.py
@@ -19,7 +19,7 @@ class CompletionModel(Model):
     super().__init__(**kwargs)
     self.model_name = model_name
 
-  def generate(self,
+  def complete(self,
                prompts: List[str],
                max_output_tokens: int = 1024,
                temperature: float = 0.0,
@@ -45,7 +45,7 @@ class CompletionModel(Model):
     self._check_response(response)
     return CompletionModelResponse(**response.json())
 
-  async def async_generate(self,
+  async def async_complete(self,
                            prompts: List[str],
                            max_output_tokens: int = 1024,
                            temperature: float = 0.0,
@@ -73,7 +73,7 @@ class CompletionModel(Model):
         await self._check_aresponse(response)
         return CompletionModelResponse(**await response.json())
 
-  def generate_stream(
+  def stream_complete(
       self,
       prompts: List[str],
       max_output_tokens: int = 1024,
@@ -102,7 +102,7 @@ class CompletionModel(Model):
     for chunk in self._parse_streaming_response(response):
       yield CompletionModelResponse(**chunk)
 
-  async def async_generate_stream(
+  async def async_stream_complete(
       self, prompts: List[str],
       max_output_tokens: int = 1024,
       temperature: float = 0.0,

--- a/src/replit/ai/embed_model.py
+++ b/src/replit/ai/embed_model.py
@@ -19,7 +19,7 @@ class EmbedModel(Model):
     super().__init__(**kwargs)
     self.model_name = model_name
 
-  def generate(self, content: List[Dict[str, Any]],
+  def embed(self, content: List[Dict[str, Any]],
             **kwargs) -> EmbeddingModelResponse:
     """
     Makes a prediction based on the content and parameters.
@@ -39,7 +39,7 @@ class EmbedModel(Model):
     self._check_response(response)
     return EmbeddingModelResponse(**response.json())
 
-  async def async_generate(self, content: List[Dict[str, Any]],
+  async def async_embed(self, content: List[Dict[str, Any]],
                    **kwargs: Dict[str, Any]) -> EmbeddingModelResponse:
     """
     Makes an asynchronous embedding generation based on the content and parameters.

--- a/src/replit/ai/google/language_models/text_embedding_model.py
+++ b/src/replit/ai/google/language_models/text_embedding_model.py
@@ -28,7 +28,7 @@ class TextEmbeddingModel:
   def get_embeddings(self, content: List[str]) -> List[TextEmbedding]:
     request = self.__ready_input(content)
     # since this model only takes the content param, we don't pass kwargs
-    response = self.underlying_model.generate(request)
+    response = self.underlying_model.embed(request)
     return self.__ready_response(response)
 
   async def async_get_embeddings(self,
@@ -36,7 +36,7 @@ class TextEmbeddingModel:
     request = self.__ready_input(content)
 
     # since this model only takes the content param, we don't pass kwargs
-    response = await self.underlying_model.async_generate(request)
+    response = await self.underlying_model.async_embed(request)
     return self.__ready_response(response)
 
   def __ready_input(self, content: List[str]) -> List[Dict[str, Any]]:

--- a/src/replit/ai/google/language_models/text_generation_model.py
+++ b/src/replit/ai/google/language_models/text_generation_model.py
@@ -11,7 +11,7 @@ class TextGenerationModel:
 
   Methods:
       from_pretrained - Loads a pretrained model using its identifier
-      predict - Generates a human-like text given an initial prompt.
+      predict - completes a human-like text given an initial prompt.
       async_predict - Async version of the predict method.
   """
 
@@ -34,31 +34,31 @@ class TextGenerationModel:
 
   def predict(self, prompt: str, **kwargs) -> TextGenerationResponse:
     """
-    Generates a human-like text given an initial prompt.
+    completes a human-like text given an initial prompt.
 
     Args:
         prompt (str): The initial text to start the generation.
 
     Returns:
-        TextGenerationResponse: The model's response containing the generated text.
+        TextGenerationResponse: The model's response containing the completed text.
     """
     parameters = ready_parameters(kwargs)
-    response = self.underlying_model.generate([prompt], **parameters)
+    response = self.underlying_model.complete([prompt], **parameters)
     return self.__ready_response(response)
 
   def predict_streaming(self, prompt: str,
                         **kwargs) -> Iterator[TextGenerationResponse]:
     """
-    Generates a human-like text given an initial prompt.
+    completes a human-like text given an initial prompt.
 
     Args:
         prompt (str): The initial text to start the generation.
 
     Returns:
-        TextGenerationResponse: The model's response containing the generated text.
+        TextGenerationResponse: The model's response containing the completed text.
     """
     parameters = ready_parameters(kwargs)
-    response = self.underlying_model.generate_stream([prompt], **parameters)
+    response = self.underlying_model.stream_complete([prompt], **parameters)
     for x in response:
       yield self.__ready_response(x)
 
@@ -71,10 +71,10 @@ class TextGenerationModel:
         prompt (str): The initial text to start the generation.
 
     Returns:
-        TextGenerationResponse: The model's response containing the generated text.
+        TextGenerationResponse: The model's response containing the completed text.
     """
     parameters = ready_parameters(kwargs)
-    response = await self.underlying_model.async_generate([prompt], **parameters)
+    response = await self.underlying_model.async_complete([prompt], **parameters)
     return self.__ready_response(response)
 
   async def async_predict_streaming(self, prompt: str,
@@ -86,10 +86,10 @@ class TextGenerationModel:
         prompt (str): The initial text to start the generation.
 
     Returns:
-        TextGenerationResponse: The model's response containing the generated text.
+        TextGenerationResponse: The model's response containing the completed text.
     """
     parameters = ready_parameters(kwargs)
-    response = self.underlying_model.async_generate_stream([prompt], **parameters)
+    response = self.underlying_model.async_stream_complete([prompt], **parameters)
     async for x in response:
       yield self.__ready_response(x)
 

--- a/src/replit/ai/google/preview/language_models/chat_model.py
+++ b/src/replit/ai/google/preview/language_models/chat_model.py
@@ -44,7 +44,7 @@ class ChatSession:
     self.add_user_message(message)
     predictParams = dict(**self.parameters, **kwargs)
     session = self.get_chat_session()
-    response = self.underlying_model.generate([session],
+    response = self.underlying_model.chat([session],
                                              **ready_parameters(predictParams))
     self.add_model_message(self.__get_response_content(response))
     return self.__ready_response(response)
@@ -53,7 +53,7 @@ class ChatSession:
     self.add_user_message(message)
     predictParams = dict(**self.parameters, **kwargs)
     session = self.get_chat_session()
-    response = await self.underlying_model.async_generate(
+    response = await self.underlying_model.async_chat(
         [session], **ready_parameters(predictParams))
     self.add_model_message(self.__get_response_content(response))
     return self.__ready_response(response)
@@ -63,7 +63,7 @@ class ChatSession:
     predictParams = dict(**self.parameters, **kwargs)
     session = self.get_chat_session()
 
-    response = self.underlying_model.generate_stream(
+    response = self.underlying_model.stream_chat(
         [session], **ready_parameters(predictParams))
     message = ""
     for chunk in response:
@@ -76,7 +76,7 @@ class ChatSession:
     newMessage = self.add_user_message(message)
     predictParams = dict(**self.parameters, **kwargs)
     session = self.get_chat_session()
-    response = self.underlying_model.async_generate_stream(
+    response = self.underlying_model.async_stream_chat(
         [session], **ready_parameters(predictParams))
     message = ""
     async for chunk in response:

--- a/src/replit/ai/model.py
+++ b/src/replit/ai/model.py
@@ -31,19 +31,6 @@ class Model:
     """
     self.server_url = kwargs.get('server_url') or get_config().rootUrl
 
-  def generate(self, prompt, parameters):
-    """
-    The method for making predictions.
-    
-    Parameters:
-        prompt: The input prompt for the prediction.
-        parameters: Additional parameters for the prediction.
-        
-    Raises:
-        NotImplementedError: This method must be implemented by subclasses.
-    """
-    raise NotImplementedError(
-        "Subclasses of Model must implement predict(self, prompt, parameters)")
 
   def _check_response(self, response):
     """

--- a/src/replit/tests/test_chat_model.py
+++ b/src/replit/tests/test_chat_model.py
@@ -20,7 +20,7 @@ PROMPT = [
 # kwargs for different endpoints and cases
 
 VALID_KWARGS = {"topP": 0.1, "topK": 20, "stopSequences": ["\n"], "candidateCount": 5}
-# generate_stream endpoint does not support the candidateCount arg
+# stream_chat endpoint does not support the candidateCount arg
 VALID_GEN_STREAM_KWARGS = {"max_output_tokens": 128, "temperature": 0, "topP": 0.1, "topK": 20}
 INVALID_KWARGS = {"invalid_parameter": 0.5}
 
@@ -30,8 +30,8 @@ INVALID_KWARGS = {"invalid_parameter": 0.5}
 def model():
   return ChatModel("chat-bison")
 
-def test_chat_model_generate(model):
-  response = model.generate(PROMPT, **VALID_KWARGS)
+def test_chat_model_chat(model):
+  response = model.chat(PROMPT, **VALID_KWARGS)
 
   assert len(response.responses) == 1
   assert len(response.responses[0].candidates) == 1
@@ -43,8 +43,8 @@ def test_chat_model_generate(model):
   choice_metadata = candidate.metadata
   assert choice_metadata['safetyAttributes']['blocked'] is False
 
-def test_chat_model_generate_no_kwargs(model):
-  response = model.generate(PROMPT)
+def test_chat_model_chat_no_kwargs(model):
+  response = model.chat(PROMPT)
 
   assert len(response.responses) == 1
   assert len(response.responses[0].candidates) == 1
@@ -56,15 +56,15 @@ def test_chat_model_generate_no_kwargs(model):
   choice_metadata = candidate.metadata
   assert choice_metadata['safetyAttributes']['blocked'] is False
 
-def test_chat_model_generate_invalid_parameter(model):
+def test_chat_model_chat_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    model.generate(PROMPT, **INVALID_KWARGS)
+    model.chat(PROMPT, **INVALID_KWARGS)
 
     
     
 @pytest.mark.asyncio
-async def test_chat_model_async_generate(model):
-  response = await model.async_generate(PROMPT, **VALID_KWARGS)
+async def test_chat_model_async_chat(model):
+  response = await model.async_chat(PROMPT, **VALID_KWARGS)
 
   assert len(response.responses) == 1
   assert len(response.responses[0].candidates) == 1
@@ -78,13 +78,13 @@ async def test_chat_model_async_generate(model):
 
 
 @pytest.mark.asyncio
-async def test_chat_model_async_generate_invalid_parameter(model):
+async def test_chat_model_async_chat_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    await model.async_generate(PROMPT, **INVALID_KWARGS)
+    await model.async_chat(PROMPT, **INVALID_KWARGS)
 
 
-def test_chat_model_generate_stream(model):
-  responses = list(model.generate_stream(PROMPT, **VALID_GEN_STREAM_KWARGS))
+def test_chat_model_stream_chat(model):
+  responses = list(model.stream_chat(PROMPT, **VALID_GEN_STREAM_KWARGS))
 
   assert len(responses) > 1
   for response in responses:
@@ -95,23 +95,23 @@ def test_chat_model_generate_stream(model):
     assert len(candidate.message.content) >= 1
 
 
-def test_chat_model_generate_stream_invalid_parameter(model):
+def test_chat_model_stream_chat_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    list(model.generate_stream(PROMPT, **INVALID_KWARGS))
+    list(model.stream_chat(PROMPT, **INVALID_KWARGS))
 
 
-def test_chat_model_generate_stream_raises_with_candidate_count_param(model):
+def test_chat_model_stream_chat_raises_with_candidate_count_param(model):
   """
-  Test that generate_stream raises an exception if candidate_count is specified.
+  Test that stream_chat raises an exception if candidate_count is specified.
   """
   INVALID_CANDIDATE_COUNT_KWARGS = {"candidateCount":5 }
   with pytest.raises(BadRequestException):
-    list(model.generate_stream(PROMPT, **INVALID_CANDIDATE_COUNT_KWARGS))
+    list(model.stream_chat(PROMPT, **INVALID_CANDIDATE_COUNT_KWARGS))
 
 @pytest.mark.asyncio
-async def test_chat_model_async_generate_stream(model):
+async def test_chat_model_async_stream_chat(model):
   responses = [
-      res async for res in model.async_generate_stream(PROMPT, **VALID_GEN_STREAM_KWARGS)
+      res async for res in model.async_stream_chat(PROMPT, **VALID_GEN_STREAM_KWARGS)
   ]
 
   assert len(responses) > 1
@@ -124,7 +124,7 @@ async def test_chat_model_async_generate_stream(model):
 
 
 @pytest.mark.asyncio
-async def test_chat_model_async_generate_stream_invalid_parameter(model):
+async def test_chat_model_async_stream_chat_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    async for _ in model.async_generate_stream(PROMPT, **INVALID_KWARGS):
+    async for _ in model.async_stream_chat(PROMPT, **INVALID_KWARGS):
       pass

--- a/src/replit/tests/test_completion_model.py
+++ b/src/replit/tests/test_completion_model.py
@@ -13,7 +13,7 @@ VALID_KWARGS = {
     "stopSequences": ["\n"],
     "candidateCount": 5
 }
-# generate_stream endpoint does not support the candidateCount arg
+# stream_complete endpoint does not support the candidateCount arg
 VALID_GEN_STREAM_KWARGS = {
     "max_output_tokens": 128,
     "temperature": 0,
@@ -29,8 +29,8 @@ def model():
   return CompletionModel("text-bison")
 
 
-def test_completion_model_generate(model):
-  response = model.generate(PROMPT, **VALID_KWARGS)
+def test_completion_model_complete(model):
+  response = model.complete(PROMPT, **VALID_KWARGS)
 
   assert len(response.responses) == 1
   assert len(response.responses[0].choices) == 1
@@ -43,14 +43,14 @@ def test_completion_model_generate(model):
   assert choice_metadata['safetyAttributes']['blocked'] is False
 
 
-def test_completion_model_generate_invalid_parameter(model):
+def test_completion_model_complete_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    model.generate(PROMPT, **INVALID_KWARGS)
+    model.complete(PROMPT, **INVALID_KWARGS)
 
 
 @pytest.mark.asyncio
-async def test_completion_model_async_generate(model):
-  response = await model.async_generate(PROMPT, **VALID_KWARGS)
+async def test_completion_model_async_complete(model):
+  response = await model.async_complete(PROMPT, **VALID_KWARGS)
 
   assert len(response.responses) == 1
   assert len(response.responses[0].choices) == 1
@@ -64,14 +64,14 @@ async def test_completion_model_async_generate(model):
 
 
 @pytest.mark.asyncio
-async def test_completion_model_apredict_invalid_parameter(model):
+async def test_completion_model_async_complete_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    await model.async_generate(PROMPT, **INVALID_KWARGS)
+    await model.async_complete(PROMPT, **INVALID_KWARGS)
 
 
-def test_completion_model_predict_stream(model):
+def test_completion_model_stream_complete(model):
   responses = list(
-      model.generate_stream(LONG_PROMPT, **VALID_GEN_STREAM_KWARGS))
+      model.stream_complete(LONG_PROMPT, **VALID_GEN_STREAM_KWARGS))
 
   assert len(responses) > 1
   for response in responses:
@@ -83,15 +83,15 @@ def test_completion_model_predict_stream(model):
     assert choice.content is not None
 
 
-def test_completion_model_generate_stream_invalid_parameter(model):
+def test_completion_model_stream_complete_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    list(model.generate_stream(PROMPT, **INVALID_KWARGS))
+    list(model.stream_complete(PROMPT, **INVALID_KWARGS))
 
 
 @pytest.mark.asyncio
-async def test_completion_model_async_generate_stream(model):
+async def test_completion_model_async_stream_complete(model):
   responses = [
-      res async for res in model.async_generate_stream(
+      res async for res in model.async_stream_complete(
           LONG_PROMPT, **VALID_GEN_STREAM_KWARGS)
   ]
 
@@ -106,7 +106,7 @@ async def test_completion_model_async_generate_stream(model):
 
 
 @pytest.mark.asyncio
-async def test_completion_model_async_generate_stream_invalid_parameter(model):
+async def test_completion_model_async_stream_complete_invalid_parameter(model):
   with pytest.raises(BadRequestException):
-    async for _ in model.async_generate_stream(LONG_PROMPT, **INVALID_KWARGS):
+    async for _ in model.async_stream_complete(LONG_PROMPT, **INVALID_KWARGS):
       pass

--- a/src/replit/tests/test_embed_model.py
+++ b/src/replit/tests/test_embed_model.py
@@ -12,8 +12,8 @@ def model():
   return EmbedModel("textembedding-gecko")
 
 
-def test_embed_model_generate(model):
-  response = model.generate(CONTENT)
+def test_embed_model_embed(model):
+  response = model.embed(CONTENT)
   assert len(response.embeddings) == 1
 
   embedding = response.embeddings[0]
@@ -27,8 +27,8 @@ def test_embed_model_generate(model):
 
 
 @pytest.mark.asyncio
-async def test_embed_model_async_generate(model):
-  response = await model.async_generate(CONTENT)
+async def test_embed_model_async_embed(model):
+  response = await model.async_embed(CONTENT)
   assert len(response.embeddings) == 1
 
   embedding = response.embeddings[0]


### PR DESCRIPTION
We want to make the API such that we pass in some named args for ease of use and then all other additional generation params through kwargs. 

The named args are the same named args in the TS library. 