### PR TITLE
feat: add ImageGenerationModel Class

### DIFF
--- a/src/replit/ai/modelfarm/__init__.py
+++ b/src/replit/ai/modelfarm/__init__.py
@@ -1,6 +1,7 @@
 from .completion_model import CompletionModel as CompletionModel
 from .chat_model import ChatModel as ChatModel
 from .embedding_model import EmbeddingModel as EmbeddingModel
+from .image_generation_model import ImageGenerationModel as ImageGenerationModel
 from .structs import (
     TokenCountMetadata as TokenCountMetadata,
     Metadata as Metadata,
@@ -19,6 +20,11 @@ from .structs import (
     EmbeddingMetadata as EmbeddingMetadata,
     EmbeddingModelRequest as EmbeddingModelRequest,
     EmbeddingModelResponse as EmbeddingModelResponse,
+    ImageSizeInput as ImageSizeInput,
+    ImageSize as ImageSize,
+    LoraWeight as LoraWeight,
+    ImageGenerationModelResponse as ImageGenerationModelResponse,
+    ImageGenerationModelImageResult as ImageGenerationModelImageResult,
 )
 
 __version__ = "0.1.0"

--- a/src/replit/ai/modelfarm/image_generation_model.py
+++ b/src/replit/ai/modelfarm/image_generation_model.py
@@ -1,0 +1,170 @@
+import os
+import requests
+import aiohttp
+from .model import Model
+from .structs import ImageGenerationModelResponse, LoraWeight, ImageSizeInput
+from typing import Optional, Any, Dict, Literal
+
+DEFAULT_LORA_URL = "https://110602490-lora.gateway.alpha.fal.ai"
+
+
+Scheduler = Literal[
+    "DPM++ 2M",
+    "DPM++ 2M Karras",
+    "DPM++ 2M SDE",
+    "DPM++ 2M SDE Karras",
+    "Euler",
+    "Euler A",
+]
+
+
+class ImageGenerationModel(Model):
+    """Generates images on fal infrastructure."""
+
+    def __init__(
+        self,
+        model_url: Optional[str] = None,
+        fal_key_id: Optional[str] = None,
+        fal_key_secret: Optional[str] = None,
+        **kwargs: Dict[str, Any],
+    ):
+        """
+        Initializes a ImageGenerationModel instance.
+
+        Args:
+          model_url (Optional[str]): Url to serving ImageGeneration Lora model
+          fal_key_id (Optional[str]): Fal credentials key id
+          fal_key_secret (Optional[str]): Fal credentials key secret
+          **kwargs (Dict[str, Any]): Additional keyword arguments.
+        """
+        self.model_url = model_url if model_url else DEFAULT_LORA_URL
+        self.fal_key_id = fal_key_id if fal_key_id else os.environ.get("FAL_KEY_ID")
+        self.fal_key_secret = (
+            fal_key_secret if fal_key_secret else os.environ.get("FAL_KEY_SECRET")
+        )
+
+        if not self.fal_key_id or not self.fal_key_secret:
+            raise ValueError(
+                "Both fal_key_id and fal_key_secret must be provided or set as environment variables."
+            )
+
+    async def async_generate(
+        self,
+        prompt: str,
+        model_name: str = "stabilityai/stable-diffusion-xl-base-1.0",
+        negative_prompt: str = "",
+        loras: list[LoraWeight] = [],
+        seed: Optional[int] = None,
+        image_size: ImageSizeInput = "square_hd",
+        num_inference_steps: int = 30,
+        guidance_scale: float = 7.5,
+        clip_skip: int = 0,
+        model_architecture: Optional[Literal["sd", "sdxl"]] = None,
+        scheduler: Optional[Scheduler] = None,
+        image_format: Literal["jpeg", "png"] = "png",
+        num_images: int = 1,
+    ) -> ImageGenerationModelResponse:
+        """
+        Asynchronously generate an image from a text prompt.
+
+        Parameters:
+            prompt (str): The prompt to use for generating the image
+            model_name (str): URL or HuggingFace ID of the base model to generate the image
+            negative_prompt (str): Prompt for details that you don't want in the image
+            loras (list[LoraWeight]): The LoRAs to use for the image generation
+            seed (int): Same seed and prompt given to a model will result in same image
+            image_size (ImageSizeInput): The size of the generated image
+            num_inference_steps (int): Number of inference steps
+            guidance_scale (float): Guidance scale (CFG)
+            clip_skip (int): Skips part of the image generation process
+            model_architecture (str): The architecture of the model to use, "sd" or "sdxl"
+            scheduler (str): Scheduler / sampler to use for the image denoising process
+            image_format (str): The format of the generated image, "png" or "jpeg"
+            num_images (int): Number of images to generate in one request
+
+        Returns:
+            ImageGenerationModelResponse
+        """
+        url = f"{self.model_url}"
+        headers = {"Authorization": f"Basic {self.fal_key_id}:{self.fal_key_secret}"}
+        params = {
+            "prompt": prompt,
+            "model_name": model_name,
+            "negative_prompt": negative_prompt,
+            "loras": loras,
+            "seed": seed,
+            "image_size": image_size,
+            "num_inference_steps": num_inference_steps,
+            "guidance_scale": guidance_scale,
+            "clip_skip": clip_skip,
+            "model_architecture": model_architecture,
+            "scheduler": scheduler,
+            "image_format": image_format,
+            "num_images": num_images,
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=params) as response:
+                await self._check_aresponse(response)
+                return ImageGenerationModelResponse(**await response.json())
+
+    def generate(
+        self,
+        prompt: str,
+        model_name: str = "stabilityai/stable-diffusion-xl-base-1.0",
+        negative_prompt: str = "",
+        loras: list[LoraWeight] = [],
+        seed: Optional[int] = None,
+        image_size: ImageSizeInput = "square_hd",
+        num_inference_steps: int = 30,
+        guidance_scale: float = 7.5,
+        clip_skip: int = 0,
+        model_architecture: Optional[Literal["sd", "sdxl"]] = None,
+        scheduler: Optional[Scheduler] = None,
+        image_format: Literal["jpeg", "png"] = "png",
+        num_images: int = 1,
+    ):
+        """
+        Generate an image from a text prompt.
+
+        Parameters:
+            prompt (str): The prompt to use for generating the image
+            model_name (str): URL or HuggingFace ID of the base model to generate the image
+            negative_prompt (str): Prompt for details that you don't want in the image
+            loras (list[LoraWeight]): The LoRAs to use for the image generation
+            seed (int): Same seed and prompt given to a model will result in same image
+            image_size (ImageSizeInput): The size of the generated image
+            num_inference_steps (int): Number of inference steps
+            guidance_scale (float): Guidance scale (CFG)
+            clip_skip (int): Skips part of the image generation process
+            model_architecture (str): The architecture of the model to use, "sd" or "sdxl"
+            scheduler (str): Scheduler / sampler to use for the image denoising process
+            image_format (str): The format of the generated image, "png" or "jpeg"
+            num_images (int): Number of images to generate in one request
+
+        Returns:
+            ImageGenerationModelResponse
+        """
+        url = f"{self.model_url}"
+        headers = {"Authorization": f"Basic {self.fal_key_id}:{self.fal_key_secret}"}
+        response = requests.post(
+            url,
+            headers=headers,
+            json={
+                "prompt": prompt,
+                "model_name": model_name,
+                "negative_prompt": negative_prompt,
+                "loras": loras,
+                "seed": seed,
+                "image_size": image_size,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "clip_skip": clip_skip,
+                "model_architecture": model_architecture,
+                "scheduler": scheduler,
+                "image_format": image_format,
+                "num_images": num_images,
+            },
+        )
+        self._check_response(response)
+        return ImageGenerationModelResponse(**response.json())

--- a/src/replit/ai/modelfarm/structs.py
+++ b/src/replit/ai/modelfarm/structs.py
@@ -1,5 +1,5 @@
-from typing import Optional, List, Union, Dict, Any
-from pydantic import BaseModel
+from typing import Optional, List, Union, Dict, Any, Literal
+from pydantic import BaseModel, Field
 
 
 class TokenCountMetadata(BaseModel):
@@ -86,3 +86,58 @@ class EmbeddingModelRequest(BaseModel):
 class EmbeddingModelResponse(BaseModel):
     metadata: Optional[EmbeddingMetadata] = None
     embeddings: List[Embedding]
+
+
+class ImageGenerationModelImageResult(BaseModel):
+    url: str
+    content_type: str
+    file_name: str
+    file_size: int
+    width: int
+    height: int
+
+
+class ImageGenerationModelResponse(BaseModel):
+    images: List[ImageGenerationModelImageResult]
+    seed: int
+
+
+class ImageSize(BaseModel):
+    width: int = Field(
+        default=512, description="The width of the generated image.", gt=0, le=4096
+    )
+    height: int = Field(
+        default=512, description="The height of the generated image.", gt=0, le=4096
+    )
+
+
+ImageSizePreset = Literal[
+    "square_hd",
+    "square",
+    "portrait_4_3",
+    "portrait_16_9",
+    "landscape_4_3",
+    "landscape_16_9",
+]
+
+
+ImageSizeInput = Union[ImageSize, ImageSizePreset]
+
+
+class LoraWeight(BaseModel):
+    path: str = Field(
+        description="URL or the path to the LoRA weights.",
+        examples=[
+            "https://civitai.com/api/download/models/135931",
+            "https://filebin.net/3chfqasxpqu21y8n/my-custom-lora-v1.safetensors",
+        ],
+    )
+    scale: float = Field(
+        default=1.0,
+        description="""
+            The scale of the LoRA weight. This is used to scale the LoRA weight
+            before merging it with the base model.
+        """,
+        ge=0.0,
+        le=1.0,
+    )

--- a/src/replit/tests/ai/modelfarm/test_image_generation.py
+++ b/src/replit/tests/ai/modelfarm/test_image_generation.py
@@ -1,0 +1,61 @@
+import pytest
+from replit.ai.modelfarm import (
+    ImageGenerationModel,
+    ImageGenerationModelResponse,
+    ImageGenerationModelImageResult,
+)
+from replit.ai.modelfarm.exceptions import InvalidResponseException
+
+PROMPT = "A donkey walking on clouds"
+TEST_LORA_URL = "https://110602490-testlora.gateway.alpha.fal.ai"
+FAL_KEY_ID = "dummy-key-id"
+FAL_KEY_SECRET = "dummysecret"
+INVALID_MODEL_ARCH = "invalid"
+
+
+# fixture for creating ImageGenerationModel
+@pytest.fixture
+def model():
+    return ImageGenerationModel(
+        model_url=TEST_LORA_URL, fal_key_id=FAL_KEY_ID, fal_key_secret=FAL_KEY_SECRET
+    )
+
+
+def test_generate_sync(model):
+    response = model.generate(PROMPT)
+
+    assert isinstance(response, ImageGenerationModelResponse)
+
+    assert response.images
+
+    image = response.images[0]
+
+    assert isinstance(image, ImageGenerationModelImageResult)
+
+    assert image.width == 500
+
+
+def test_generate_sync_invalid_parameter(model):
+    with pytest.raises(InvalidResponseException):
+        model.generate(prompt=PROMPT, model_architecture=INVALID_MODEL_ARCH)
+
+
+@pytest.mark.asyncio
+async def test_generate_async(model):
+    response = await model.async_generate(prompt=PROMPT)
+
+    assert isinstance(response, ImageGenerationModelResponse)
+
+    assert response.images
+
+    image = response.images[0]
+
+    assert isinstance(image, ImageGenerationModelImageResult)
+
+    assert image.width == 500
+
+
+@pytest.mark.asyncio
+async def test_generate_async_invalid_parameter(model):
+    with pytest.raises(InvalidResponseException):
+        await model.generate(prompt=PROMPT, model_architecture=INVALID_MODEL_ARCH)


### PR DESCRIPTION
This PR introduces `ImageGenerationModel` class that allows for the generation of images from text prompts using the diffusion models with support for LoRAs. The inference happens on [fal](https://fal.ai). The key changes are as follows:

- **New Data Models**: Added `ImageGenerationModelImageResult`, `ImageGenerationModelResponse`, `ImageSize`, `ImageSizePreset`, `ImageSizeInput`, and `LoraWeight` data models to handle the image generation process.

- **ImageGenerationModel Class**: This is the main class that uses the above data models to generate images. It includes the following features:
  *Initialisation*: The class can be initialized with a model URL and FAL credentials. If not provided, it defaults to environment variables.
  *Image Generation*: The `generate` and `async_generate` methods allow for the synchronous and asynchronous generation of images from text prompts. These methods support various parameters such as `prompt`, `model_name`, `negative_prompt`, `loras`, `seed`, `image_size`, `num_inference_steps`, `guidance_scale`, `clip_skip`, `model_architecture`, `scheduler`, `image_format`, and `num_images`.
*Error Handling*: The class includes error handling to ensure that fal credentials are provided during initialization.

This new feature enhances the project's capabilities by allowing users to generate images from text prompts, which can be useful in a variety of applications, such as content generation, AI art, etc.

Please review and let me know if there are any concerns or suggestions for improvement.